### PR TITLE
Fix MPTT state when cloning site & restore current MPTT state

### DIFF
--- a/apps/admin/sites/views.py
+++ b/apps/admin/sites/views.py
@@ -167,6 +167,9 @@ def create(request):
             # be duplicated, it needs to be updated with its corresponding new parent
             page_id_mapping = {}
 
+            # Get the next MPTT tree_id. Unfortunately we'll have to access the internal MPTT API here.
+            new_tree_id = Page.objects._get_next_tree_id()
+
             # Order by level so that parents are guaranteed to exist when creating their children
             for page in Page.objects.filter(site=template_site).order_by('level'):
                 variants = page.variant_set.all()
@@ -174,11 +177,8 @@ def create(request):
                 page.id = None
                 page.site = site
 
-                # Reset MPTT state and let the mptt-manager recreate a new root node
-                page.tree_id = None
-                page.lft = None
-                page.rght = None
-                page.level = None
+                # Increment the tree_id and leave other MPTT fields as they were
+                page.tree_id = new_tree_id
 
                 # Set parent to the duplicated one; use the old parent id to retrieve it
                 if page.parent is None:

--- a/apps/admin/sites/views.py
+++ b/apps/admin/sites/views.py
@@ -167,6 +167,13 @@ def create(request):
                 page.id = None
                 page.site = site
 
+                # Reset MPTT state and let the mptt-manager recreate a new root node
+                page.tree_id = None
+                page.parent = None
+                page.lft = None
+                page.rght = None
+                page.level = None
+
                 # Change creation to the user creating the new site and reset modification
                 page.created_by = request.user
                 page.created_date = datetime.now()

--- a/apps/admin/sites/views.py
+++ b/apps/admin/sites/views.py
@@ -167,91 +167,87 @@ def create(request):
             # be duplicated, it needs to be updated with its corresponding new parent
             page_id_mapping = {}
 
-            # Get the next MPTT tree_id. Unfortunately we'll have to access the internal MPTT API here.
-            new_tree_id = Page.objects._get_next_tree_id()
+            # Order by the left value in order to insert new nodes in a consistent way
+            for page in Page.objects.filter(site=template_site).order_by('lft'):
+                variants = page.variant_set.all()
+                old_id = page.id
+                page.id = None
+                page.site = site
 
-            # Disable MPTT updates - assuming the template site's tree is correct, all we'll do is clone it and
-            # increase only the tree_id
-            with Page.objects.disable_mptt_updates():
-                # Order by level so that parents are guaranteed to exist when creating their children
-                for page in Page.objects.filter(site=template_site).order_by('level'):
-                    variants = page.variant_set.all()
-                    old_id = page.id
-                    page.id = None
-                    page.site = site
+                # Reset MPTT state and let our library recreate them
+                page.tree_id = None
+                page.lft = None
+                page.rght = None
+                page.level = None
 
-                    # Increment the tree_id and leave other MPTT fields as they were
-                    page.tree_id = new_tree_id
+                # Set parent to the corresponding clone; use the old parent id to retrieve it
+                if page.parent is not None:
+                    page.parent = page_id_mapping[page.parent.id]
 
-                    # Set parent to the duplicated one; use the old parent id to retrieve it
-                    if page.parent is None:
-                        page.parent = None
-                    else:
-                        page.parent = page_id_mapping[page.parent.id]
+                # Change creation to the user creating the new site and reset modification
+                page.created_by = request.user
+                page.created_date = datetime.now()
+                page.modified_by = None
+                page.modified_date = None
 
-                    # Change creation to the user creating the new site and reset modification
-                    page.created_by = request.user
-                    page.created_date = datetime.now()
-                    page.modified_by = None
-                    page.modified_date = None
+                # Insert the new node appropriately
+                if page.parent is None:
+                    Page.objects.insert_node(page, target=None, save=True)
+                else:
+                    Page.objects.insert_node(page, target=page.parent, position='last-child', save=True)
 
-                    page.save()
+                page.save()
 
-                    # Remember which old id maps to this page
-                    page_id_mapping[old_id] = page
+                # Remember which old id maps to this page
+                page_id_mapping[old_id] = page
 
-                    for variant in variants:
-                        versions = variant.version_set.all()
-                        variant.id = None
-                        variant.page = page
-                        variant.save()
+                for variant in variants:
+                    versions = variant.version_set.all()
+                    variant.id = None
+                    variant.page = page
+                    variant.save()
 
-                        for version in versions:
-                            rows = version.rows.all()
-                            version.id = None
-                            version.variant = variant
-                            version.save()
+                    for version in versions:
+                        rows = version.rows.all()
+                        version.id = None
+                        version.variant = variant
+                        version.save()
 
-                            for row in rows:
-                                columns = row.columns.all()
-                                row.id = None
-                                row.version = version
-                                row.save()
+                        for row in rows:
+                            columns = row.columns.all()
+                            row.id = None
+                            row.version = version
+                            row.save()
 
-                                for column in columns:
-                                    contents = column.contents.all()
-                                    column.id = None
-                                    column.row = row
-                                    column.save()
+                            for column in columns:
+                                contents = column.contents.all()
+                                column.id = None
+                                column.row = row
+                                column.save()
 
-                                    for content in contents:
-                                        content.id = None
-                                        content.column = column
+                                for content in contents:
+                                    content.id = None
+                                    content.column = column
 
-                                        # Replace domain references with the new site domain
-                                        # Use a json dump with prepended/trailing quotes stripped to ensure the
-                                        # replacement string is properly escaped if inserted into json-formatted
-                                        # content
-                                        json_safe_domain = json.dumps(site.domain)[1:-1]
-                                        content.content = re.sub(
-                                            template_site.domain,
-                                            json_safe_domain,
-                                            content.content
-                                        )
+                                    # Replace domain references with the new site domain
+                                    # Use a json dump with prepended/trailing quotes stripped to ensure the
+                                    # replacement string is properly escaped if inserted into json-formatted content
+                                    json_safe_domain = json.dumps(site.domain)[1:-1]
+                                    content.content = re.sub(template_site.domain, json_safe_domain, content.content)
 
-                                        # For aktiviteteslisting-widgets, force arranger-filter to the new site's
-                                        # related forening
-                                        if content.type == 'widget':
-                                            parsed_content = json.loads(content.content)
-                                            if parsed_content['widget'] == 'aktivitet_listing':
-                                                # Note that the list of ids contains strings, because we forgot to
-                                                # convert it to int in the widget-editor save logic, but that's not a
-                                                # problem since the filter lookup will implicitly convert it. So force
-                                                # it to str to be consistent
-                                                parsed_content['foreninger'] = [str(site.forening.id)]
-                                                content.content = json.dumps(parsed_content)
+                                    # For aktiviteteslisting-widgets, force arranger-filter to the new site's related
+                                    # forening
+                                    if content.type == 'widget':
+                                        parsed_content = json.loads(content.content)
+                                        if parsed_content['widget'] == 'aktivitet_listing':
+                                            # Note that the list of ids contains strings, because we forgot to convert
+                                            # it to int in the widget-editor save logic, but that's not a problem since
+                                            # the filter lookup will implicitly convert it. So force it to str to be
+                                            # consistent
+                                            parsed_content['foreninger'] = [str(site.forening.id)]
+                                            content.content = json.dumps(parsed_content)
 
-                                        content.save()
+                                    content.save()
 
             # Articles
             for article in Article.objects.filter(site=template_site):

--- a/apps/page/migrations/0005_auto_20150326_2010.py
+++ b/apps/page/migrations/0005_auto_20150326_2010.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+def fix_parents(apps, schema_editor):
+    Site = apps.get_model("core", "Site")
+    Page = apps.get_model("page", "Page")
+
+    for p in Page.objects.filter(parent__isnull=False).order_by('level'):
+        if p.site == p.parent.site:
+            continue
+
+        try:
+            new_parent = Page.objects.get(title=p.parent.title, site=p.site)
+            p.parent = new_parent
+            p.save()
+        except:
+            # Handled these manually
+            if p.parent.title == u'Våre hytter':
+                new_parent = Page.objects.get(title=u'Forside', site=p.site)
+                p.parent = new_parent
+                p.save()
+            elif p.parent.title == u'Om oss':
+                new_parent = Page.objects.get(title=u'Om TTF', site=p.site)
+                p.parent = new_parent
+                p.save()
+            else:
+                raise Exception("Unexpected page not handled manually: %s" % p.id)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('page', '0004_merge'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_parents),
+    ]

--- a/apps/page/migrations/0006_auto_20150326_2022.py
+++ b/apps/page/migrations/0006_auto_20150326_2022.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+def reset_tree_ids(apps, schema_editor):
+    Site = apps.get_model("core", "Site")
+    Page = apps.get_model("page", "Page")
+
+    # It doesn't matter what the tree ID is, as long as it's unique for each tree
+    # See http://django-mptt.github.io/django-mptt/technical_details.html
+    for tree_id, site in enumerate(Site.objects.all(), 1):
+        Page.objects.filter(site=site).update(tree_id=tree_id)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('page', '0005_auto_20150326_2010'),
+    ]
+
+    operations = [
+        migrations.RunPython(reset_tree_ids),
+    ]

--- a/apps/page/migrations/0007_auto_20150326_2047.py
+++ b/apps/page/migrations/0007_auto_20150326_2047.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+def rebuild(apps, schema_editor):
+    # We don't really care about the state of the database, as long as it's still there and using MPTT.
+    # If that's not the case, and you try to apply migrations in the faaaar future, this may come back to haunt you.
+    # In that case you don't care about the state of the data so just comment this entire method out and replace it
+    # with 'pass'. PROBLEM SOLVED! http://i.imgur.com/4mYD13u.gif
+    from page.models import Page # YES, intentional model import; not using the migration ORM layer
+    Page.objects.rebuild()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('page', '0006_auto_20150326_2022'),
+    ]
+
+    operations = [
+        migrations.RunPython(rebuild),
+    ]


### PR DESCRIPTION
### Root cause

Previously, the site cloning process didn't take the MPTT state into account. This caused a range of problems:

- The parent reference wouldn't ble updated to the new parent but still reference the template site parent
- The MPTT-internal `tree_id` field, used to separate distinct trees, wouldn't change; leaving `django-mptt` believing pages from both sites were part of the same tree
- `django-mptt` would attempt to "fix" the `left` and `right` values after each `save` during the cloning iteration, resulting in completely bogus values due to the pages sharing `tree_id` with a number of other sites

These problems are now fixed.

### Current MPTT state

Assuming the above problems are the only ones currupting the MPTT state, we can try fix the current state and hopefully the tree will stay consistent. Here's the process:

1. Fix all parent references. Note that this makes some assumptions based on the current data state and you should verify that the migration runs successfully locally before merging, se commit bc15cea for more info
2. Reset the `tree_id` counter - this discards previous values and randomly assigns a unique id for all pages on a given site
3. At this point we can safely call `Page.objects.rebuild()` to fix `left`/`right` for all pages.

*NOTE: The third migration will cause some random reordering and restructuring of existing pages, but also make sure "lost" pages reappear in the page tree. This is a necessary evil in order to clean up the current state.*