### PR TITLE
Add OAuth2 and proper CORS handling

### DIFF
--- a/apps/payment/views.py
+++ b/apps/payment/views.py
@@ -16,15 +16,6 @@ from user.models import User, CabinVisit, CabinVisitor
 @csrf_exempt
 def create_transaction(request):
     """This view is called by the phone app to initiate a new transaction"""
-    if request.method == 'OPTIONS':
-        # Handle CORS preflight
-        request_headers = request.META.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-        response = HttpResponse()
-        if request_headers is not None:
-            response['Access-Control-Allow-Headers'] = request_headers
-        response['Access-Control-Allow-Method'] = 'POST'
-        return response
-
     transaction = json.loads(request.POST['data'])
 
     sted = Sted.get(transaction['hytte'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ boto==2.9.4
 cffi==0.8.6
 cryptography==0.6.1
 django-mptt==0.6.1
+django-oauth-toolkit==0.8.0
 django-pyodbc-azure==1.2.2
 django-recaptcha==1.0.3
 djorm-pgarray==1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Pillow==2.0.0
 boto==2.9.4
 cffi==0.8.6
 cryptography==0.6.1
+django-cors-headers==1.0.0
 django-mptt==0.6.1
 django-oauth-toolkit==0.8.0
 django-pyodbc-azure==1.2.2

--- a/sherpa/conf/prod.py
+++ b/sherpa/conf/prod.py
@@ -245,6 +245,7 @@ INSTALLED_APPS = (
     'montis',
     'payment',
     'oauth2_provider',
+    'corsheaders',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (

--- a/sherpa/conf/prod.py
+++ b/sherpa/conf/prod.py
@@ -289,6 +289,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'sherpa.middleware.ChangeActiveForening',
     'sherpa.middleware.ActiveForening',
+    'sherpa.middleware.CheckOauth2ApplicationsPermission',
     'sherpa.middleware.CheckSherpaPermissions',
     'sherpa.middleware.DeactivatedEnrollment',
     'sherpa.middleware.FocusDowntime',

--- a/sherpa/conf/prod.py
+++ b/sherpa/conf/prod.py
@@ -281,6 +281,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
+    'sherpa.middleware.TemporaryCorsMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'sherpa.middleware.Redirect',
     'sherpa.middleware.DBConnection',

--- a/sherpa/conf/prod.py
+++ b/sherpa/conf/prod.py
@@ -276,6 +276,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'sherpa.middleware.Redirect',
     'sherpa.middleware.DBConnection',
     'sherpa.middleware.DefaultLanguage',

--- a/sherpa/conf/prod.py
+++ b/sherpa/conf/prod.py
@@ -212,6 +212,11 @@ EDITOR_PLACEHOLDER_IMAGE = '%simg/admin/sites/editor/placeholder.png' % STATIC_U
 DATABASE_ROUTERS = ['sherpa.db_routers.Router']
 AUTHENTICATION_BACKENDS = ('sherpa.auth_backends.CustomBackend',)
 
+# CORS settings - allow all origins given a request to the specified URLs
+CORS_URLS_REGEX = r'^/(api|ekstern-betaling)/.*$'
+CORS_ALLOW_METHODS = ('GET', 'POST')
+CORS_ORIGIN_ALLOW_ALL = True
+
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/sherpa/conf/prod.py
+++ b/sherpa/conf/prod.py
@@ -213,7 +213,7 @@ DATABASE_ROUTERS = ['sherpa.db_routers.Router']
 AUTHENTICATION_BACKENDS = ('sherpa.auth_backends.CustomBackend',)
 
 # CORS settings - allow all origins given a request to the specified URLs
-CORS_URLS_REGEX = r'^/(api|ekstern-betaling)/.*$'
+CORS_URLS_REGEX = r'^/(api|ekstern-betaling|o/token)/.*$'
 CORS_ALLOW_METHODS = ('GET', 'POST')
 CORS_ORIGIN_ALLOW_ALL = True
 

--- a/sherpa/conf/prod.py
+++ b/sherpa/conf/prod.py
@@ -244,6 +244,7 @@ INSTALLED_APPS = (
     'turbasen',
     'montis',
     'payment',
+    'oauth2_provider',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (

--- a/sherpa/conf/prod.py
+++ b/sherpa/conf/prod.py
@@ -219,9 +219,13 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.gis', # GeoDjango
+
     'raven.contrib.django', # Error logging
     'captcha', # django-recaptcha
     'mptt', # Modified Preorder Tree Traversal - see https://django-mptt.github.io/django-mptt/
+    'oauth2_provider', # django-oauth-toolkit - see https://django-oauth-toolkit.readthedocs.org/
+    'corsheaders', # django-cors-headers - see https://pypi.python.org/pypi/django-cors-headers/
+
     'focus', # Only db-models from Focus
     'sherpa2', # Only db-models from Sherpa 2
     'sherpa25', # Only db-models from Sherpa 2.5
@@ -244,8 +248,6 @@ INSTALLED_APPS = (
     'turbasen',
     'montis',
     'payment',
-    'oauth2_provider',
-    'corsheaders',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (

--- a/sherpa/middleware.py
+++ b/sherpa/middleware.py
@@ -205,6 +205,15 @@ class ActiveForening(object):
                 # It might have been removed, remove it and let the user choose a new one
                 del request.session['active_forening']
 
+class CheckOauth2ApplicationsPermission(object):
+    """The django-oauth-toolkit requires only a logged-in user. Here we'll append our own rule which is that only
+    sherpa-admins have access to managing OAuth2 applications."""
+    def process_request(self, request):
+        if request.path.startswith(u'/o/applications') and \
+            request.user.is_authenticated() and \
+            not request.user.has_perm('sherpa_admin'):
+            raise PermissionDenied()
+
 class CheckSherpaPermissions(object):
     def process_request(self, request):
         if request.current_app == 'admin':

--- a/sherpa/middleware.py
+++ b/sherpa/middleware.py
@@ -32,7 +32,9 @@ class TemporaryCorsMiddleware():
     """Temporary middleware - until we've verified that the DNT app will send an 'Origin' header so that we can use
     the corsheaders app solely for handling CORS requests, this app will handle it manually"""
     def process_request(self, request):
-        if request.path.startswith('/api/') or request.path.startswith('/ekstern-betaling/'):
+        if request.path.startswith('/api/') or \
+            request.path.startswith('/ekstern-betaling/') or \
+            request.path.startswith('/o/token/'):
             if request.method == 'OPTIONS':
                 # Handle CORS preflight
                 request_headers = request.META.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
@@ -43,7 +45,9 @@ class TemporaryCorsMiddleware():
                 return response
 
     def process_response(self, request, response):
-        if request.path.startswith('/api/') or request.path.startswith('/ekstern-betaling/'):
+        if request.path.startswith('/api/') or \
+            request.path.startswith('/ekstern-betaling/') or \
+            request.path.startswith('/o/token/'):
             response['Access-Control-Allow-Origin'] = '*'
         return response
 

--- a/sherpa/urls_central.py
+++ b/sherpa/urls_central.py
@@ -27,6 +27,8 @@ urlpatterns = patterns('',
     url(r'^api/', include('api.urls')),
     url(r'^payment/(?P<slug>.*)', 'page.views.perform_site_redirect', kwargs={'url': 'payment/'}),
 
+    url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+
     url(r'^', include('sherpa.urls_redirects_central')),
     url(r'^', include('sherpa.urls_redirects_common')),
     url(r'^', include('sherpa.urls_common_post')),

--- a/sherpa/urls_central.py
+++ b/sherpa/urls_central.py
@@ -27,6 +27,8 @@ urlpatterns = patterns('',
     url(r'^api/', include('api.urls')),
     url(r'^payment/(?P<slug>.*)', 'page.views.perform_site_redirect', kwargs={'url': 'payment/'}),
 
+    # Note that this URL (more specifically, o/applications/) is duplicated and hardcoded in the
+    # CheckOauth2ApplicationsPermission middleware
     url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 
     url(r'^', include('sherpa.urls_redirects_central')),

--- a/sherpa/urls_central.py
+++ b/sherpa/urls_central.py
@@ -24,7 +24,7 @@ urlpatterns = patterns('',
     url(r'^fotokonkurranse/', include('fotokonkurranse.urls')),
 
     url(r'^connect/', include('connect.urls')),
-    url(r'^api/', include('api.urls')),
+    url(r'^api/', include('api.urls')), # Note that this URL is used in the CORS_URLS_REGEX setting
     url(r'^payment/(?P<slug>.*)', 'page.views.perform_site_redirect', kwargs={'url': 'payment/'}),
 
     # Note that this URL (more specifically, o/applications/) is duplicated and hardcoded in the

--- a/sherpa/urls_common_pre.py
+++ b/sherpa/urls_common_pre.py
@@ -16,7 +16,7 @@ urlpatterns = patterns('',
     url(r'^nyhetsarkiv/', include('articles.urls_archive')),
     url(r'^aktiviteter/', include('aktiviteter.urls')),
     url(r'^turbasen/', include('turbasen.urls')),
-    url(r'^ekstern-betaling/', include('payment.urls')),
+    url(r'^ekstern-betaling/', include('payment.urls')), # Note that this URL is used in the CORS_URLS_REGEX setting
 
     url(r'^i18n/', include('django.conf.urls.i18n')),
 )


### PR DESCRIPTION
- Adds OAuth2 library
- Adds a membership data endpoint *with custom validation* as the `oauth2_provider.backends.OAuth2Backend` authentication backend didn't seem to work
- Includes temporary custom middleware for CORS which should be removed when we verify that the DNT app can send "Origin" header (the `corsheader` lib won't work without that)
- Protects the OAuth2 application view with a custom middleware which checks for the `sherpa_admin` permission

Endpoints:

- /o/applications/ - application management (internal)
- /o/authorize/ - initial authorization request endpoint
- /o/token/ - access token request endpoint
- /api/oauth/medlemsdata/ - oauth protected membership data resource